### PR TITLE
feature: Ensure rankings use latest results before zen score sort

### DIFF
--- a/src/__tests__/rankings.api.test.ts
+++ b/src/__tests__/rankings.api.test.ts
@@ -87,6 +87,7 @@ describe('Rankings API', () => {
 
     expect(mockFindMany()).toHaveBeenCalledWith({
       where: undefined,
+      orderBy: { createdAt: 'desc' },
       take: 50,
       select: {
         wordsPerMinute: true,
@@ -121,6 +122,7 @@ describe('Rankings API', () => {
 
     const call = mockFindMany().mock.calls[0]?.[0];
     expect(call.take).toBe(10);
+    expect(call.orderBy).toEqual({ createdAt: 'desc' });
     expect(call.where).toBeDefined();
     const gte: Date | undefined = call.where?.createdAt?.gte;
     expect(gte).toBeInstanceOf(Date);

--- a/src/app/api/rankings/route.ts
+++ b/src/app/api/rankings/route.ts
@@ -50,6 +50,7 @@ export const GET = async (req: Request) => {
 
   const results = await prisma.gameResult.findMany({
     where: gte ? { createdAt: { gte } } : undefined,
+    orderBy: { createdAt: 'desc' },
     take: limit,
     select: {
       wordsPerMinute: true,


### PR DESCRIPTION
- ランキング取得時にcreatedAt 降順で並べてから Zen Score でソートするよう変更し、all time / monthly でも最新結果が反映されるように修正
- テストを更新し、デフォルトと time frame 指定時に作成日時の降順が使われることを検証