### PR TITLE
SEOメタデータとURL解決の堅牢性を改善

### DIFF
--- a/src/__tests__/site-url.test.ts
+++ b/src/__tests__/site-url.test.ts
@@ -30,6 +30,13 @@ describe('site-url', () => {
     expect(getSiteUrl()).toBe('http://localhost:3000');
   });
 
+  test('getSiteUrl ignores empty and invalid env values', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = '';
+    process.env.NEXTAUTH_URL = 'not-a-url';
+
+    expect(getSiteUrl()).toBe('http://localhost:3000');
+  });
+
   test('absoluteUrl normalizes both prefixed and non-prefixed paths', () => {
     process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'About | Koto-Koto',
+  description:
+    'Koto-Koto is a Japanese typing game with zen-inspired visuals, mechanical keyboard sounds, and ranking features.',
+  alternates: {
+    canonical: '/about',
+  },
+};
+
+export default function AboutPage() {
+  return (
+    <main className="h-screen overflow-y-auto pt-28 pb-16 px-6 md:px-12">
+      <div className="mx-auto w-full max-w-4xl rounded-2xl border border-white/10 bg-black/30 p-6 md:p-10 backdrop-blur">
+        <h1 className="text-3xl md:text-4xl tracking-wide font-semibold">About Koto-Koto</h1>
+        <p className="mt-3 text-sm leading-6 text-off-white/90">
+          Koto-Koto is a web-based Japanese typing game designed for focused and repeatable
+          practice. The experience combines calm visual presentation, responsive key input, and a
+          mechanical keyboard-inspired sound system.
+        </p>
+
+        <section className="mt-8">
+          <h2 className="text-lg md:text-xl font-medium tracking-wide">What You Can Do</h2>
+          <p className="mt-2 text-off-white/90 leading-7">
+            Play in classic and endless modes, review your typing history, and check rankings. The
+            typing engine accepts common romaji variations to keep input natural while scoring
+            remains consistent.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-lg md:text-xl font-medium tracking-wide">Design Direction</h2>
+          <p className="mt-2 text-off-white/90 leading-7">
+            The interface aims for a quiet and minimal atmosphere to support concentration. Visual
+            and audio choices are tuned to reduce noise while preserving clear interaction feedback.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-lg md:text-xl font-medium tracking-wide">Related Pages</h2>
+          <ul className="mt-3 space-y-2 text-off-white/90">
+            <li>
+              <Link href="/terms" className="underline decoration-white/30 underline-offset-4">
+                Terms of Service
+              </Link>
+            </li>
+            <li>
+              <Link href="/privacy" className="underline decoration-white/30 underline-offset-4">
+                Privacy Policy
+              </Link>
+            </li>
+            <li>
+              <Link href="/licenses" className="underline decoration-white/30 underline-offset-4">
+                Licenses
+              </Link>
+            </li>
+          </ul>
+        </section>
+
+        <section className="mt-12 border-t border-white/10 pt-8">
+          <h2 className="text-2xl md:text-3xl tracking-wide font-semibold">Koto-Koto について</h2>
+          <p className="mt-3 text-sm leading-6 text-off-white/90">
+            Koto-Kotoは、集中して反復練習できるように設計したWebベースの日本語タイピングゲームです。静かな
+            ビジュアル表現と反応性の高い入力処理、メカニカルキーボード風のサウンドを組み合わせています。
+          </p>
+
+          <section className="mt-8">
+            <h3 className="text-lg md:text-xl font-medium tracking-wide">できること</h3>
+            <p className="mt-2 text-off-white/90 leading-7">
+              クラシック/エンドレスの各モードで練習し、履歴とランキングで結果を確認できます。一般的なローマ字
+              揺れを許容しつつ、スコア評価の一貫性を保つ入力エンジンを採用しています。
+            </p>
+          </section>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: Readonly<{
+  error: Error & { digest?: string };
+  reset: () => void;
+}>) {
+  useEffect(() => {
+    console.error('Unhandled app error:', error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen bg-zen-dark relative flex items-center justify-center px-6">
+      <div className="noise-overlay" />
+      <section className="relative z-10 w-full max-w-xl rounded-2xl border border-white/10 bg-black/30 p-8 backdrop-blur text-center">
+        <p className="text-xs uppercase tracking-[0.24em] text-subtle-gray">500 Server Error</p>
+        <h1 className="mt-3 text-2xl md:text-3xl font-semibold tracking-wide">
+          Something went wrong.
+        </h1>
+        <p className="mt-4 text-sm md:text-base text-off-white/80 leading-relaxed">
+          Please retry. If the issue persists, return to the home page and try again later.
+        </p>
+        <div className="mt-6 flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-5 py-2 text-xs uppercase tracking-[0.2em] hover:bg-white/20 transition-colors"
+          >
+            Retry
+          </button>
+          <Link
+            href="/"
+            className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-5 py-2 text-xs uppercase tracking-[0.2em] hover:bg-white/20 transition-colors"
+          >
+            Home
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import './globals.css';
 import MobileBlocker from '@/components/MobileBlocker';
 import Providers from '@/components/Providers';
 import AppHeader from '@/components/AppHeader';
-import { getSiteUrl } from '@/lib/site-url';
+import { absoluteUrl, getSiteUrl } from '@/lib/site-url';
 
 const zenOldMincho = Zen_Old_Mincho({
   weight: ['400', '500', '700', '900'],
@@ -17,6 +17,19 @@ export const metadata: Metadata = {
   title: 'Koto-Koto',
   description: 'A digital Zen garden typing experience.',
   metadataBase: new URL(getSiteUrl()),
+  openGraph: {
+    type: 'website',
+    url: '/',
+    siteName: 'Koto-Koto',
+    title: 'Koto-Koto',
+    description: 'A digital Zen garden typing experience.',
+    locale: 'ja_JP',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Koto-Koto',
+    description: 'A digital Zen garden typing experience.',
+  },
   alternates: {
     canonical: '/',
   },
@@ -29,6 +42,24 @@ export const metadata: Metadata = {
   },
 };
 
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Koto-Koto',
+  url: getSiteUrl(),
+  inLanguage: ['ja', 'en'],
+  description: 'A digital Zen garden typing experience.',
+};
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Koto-Koto',
+  url: getSiteUrl(),
+  logo: absoluteUrl('/favicon.ico'),
+  sameAs: ['https://github.com/Aoi3u/koto-koto'],
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -36,6 +67,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
+      </head>
       <body
         className={`${zenOldMincho.variable} antialiased bg-zen-dark text-off-white overflow-hidden`}
         style={{ fontFamily: 'var(--font-zen-old-mincho, sans-serif)' }}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-zen-dark relative flex items-center justify-center px-6">
+      <div className="noise-overlay" />
+      <section className="relative z-10 w-full max-w-xl rounded-2xl border border-white/10 bg-black/30 p-8 backdrop-blur text-center">
+        <p className="text-xs uppercase tracking-[0.24em] text-subtle-gray">404 Not Found</p>
+        <h1 className="mt-3 text-2xl md:text-3xl font-semibold tracking-wide">
+          The page could not be found.
+        </h1>
+        <p className="mt-4 text-sm md:text-base text-off-white/80 leading-relaxed">
+          The link may be broken, or the page may have been moved.
+        </p>
+        <div className="mt-6">
+          <Link
+            href="/"
+            className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-5 py-2 text-xs uppercase tracking-[0.2em] hover:bg-white/20 transition-colors"
+          >
+            Back to Home
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,33 +1,45 @@
 import type { MetadataRoute } from 'next';
 import { absoluteUrl } from '@/lib/site-url';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const now = new Date();
+const LAST_MODIFIED = {
+  home: new Date('2026-04-06T00:00:00.000Z'),
+  terms: new Date('2026-04-06T00:00:00.000Z'),
+  privacy: new Date('2026-04-06T00:00:00.000Z'),
+  licenses: new Date('2026-04-06T00:00:00.000Z'),
+  about: new Date('2026-04-06T00:00:00.000Z'),
+};
 
+export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: absoluteUrl('/'),
-      lastModified: now,
+      lastModified: LAST_MODIFIED.home,
       changeFrequency: 'weekly',
       priority: 1,
     },
     {
       url: absoluteUrl('/terms'),
-      lastModified: now,
+      lastModified: LAST_MODIFIED.terms,
       changeFrequency: 'yearly',
       priority: 0.4,
     },
     {
       url: absoluteUrl('/privacy'),
-      lastModified: now,
+      lastModified: LAST_MODIFIED.privacy,
       changeFrequency: 'yearly',
       priority: 0.4,
     },
     {
       url: absoluteUrl('/licenses'),
-      lastModified: now,
+      lastModified: LAST_MODIFIED.licenses,
       changeFrequency: 'yearly',
       priority: 0.3,
+    },
+    {
+      url: absoluteUrl('/about'),
+      lastModified: LAST_MODIFIED.about,
+      changeFrequency: 'monthly',
+      priority: 0.5,
     },
   ];
 }

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -15,6 +15,7 @@ import {
   ScrollText,
   ShieldCheck,
   FileText,
+  Info,
 } from 'lucide-react';
 import IconActionButton from '@/components/ui/IconActionButton';
 import { useThemePalette } from '@/contexts/SeasonalContext';
@@ -126,37 +127,14 @@ export default function AppHeader() {
 
                   <div className="my-2 border-t border-white/5" />
 
-                  {/* Sound Settings */}
-                  <div className="px-3 py-2">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="text-xs text-subtle-gray font-zen-old-mincho tracking-wider">
-                        Keyboard Sound
-                      </span>
-                      {!hasAudioSupport && <VolumeX className="w-3 h-3 text-red-400" />}
-                    </div>
-                    <div className="grid grid-cols-1 gap-1 max-h-30 overflow-y-auto pr-1 custom-scrollbar">
-                      {profiles.map((profile) => (
-                        <button
-                          key={profile}
-                          onClick={() => changeProfile(profile)}
-                          disabled={!hasAudioSupport || isProfileLoading}
-                          className={`flex items-center justify-between px-2 py-1.5 rounded text-xs transition-all ${
-                            currentProfile === profile
-                              ? 'bg-white/10 text-off-white'
-                              : 'text-subtle-gray hover:bg-white/5 hover:text-off-white'
-                          }`}
-                        >
-                          <span>{availableProfiles[profile].name}</span>
-                          {currentProfile === profile && (
-                            <div
-                              className="w-1.5 h-1.5 rounded-full"
-                              style={{ backgroundColor: palette.primary }}
-                            />
-                          )}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
+                  <Link
+                    href="/about"
+                    onClick={() => setIsOpen(false)}
+                    className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/5 text-sm text-off-white transition-colors group"
+                  >
+                    <Info className="w-4 h-4 text-subtle-gray group-hover:text-off-white" />
+                    <span className="font-zen-old-mincho tracking-wider">About</span>
+                  </Link>
 
                   <Link
                     href="/terms"
@@ -184,6 +162,38 @@ export default function AppHeader() {
                     <FileText className="w-4 h-4 text-subtle-gray group-hover:text-off-white" />
                     <span className="font-zen-old-mincho tracking-wider">Licenses</span>
                   </Link>
+
+                  {/* Sound Settings */}
+                  <div className="px-3 py-2">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-xs text-subtle-gray font-zen-old-mincho tracking-wider">
+                        Keyboard Sound
+                      </span>
+                      {!hasAudioSupport && <VolumeX className="w-3 h-3 text-red-400" />}
+                    </div>
+                    <div className="grid grid-cols-1 gap-1 max-h-40 overflow-y-auto pr-1 custom-scrollbar">
+                      {profiles.map((profile) => (
+                        <button
+                          key={profile}
+                          onClick={() => changeProfile(profile)}
+                          disabled={!hasAudioSupport || isProfileLoading}
+                          className={`flex items-center justify-between px-2 py-1.5 rounded text-xs transition-all ${
+                            currentProfile === profile
+                              ? 'bg-white/10 text-off-white'
+                              : 'text-subtle-gray hover:bg-white/5 hover:text-off-white'
+                          }`}
+                        >
+                          <span>{availableProfiles[profile].name}</span>
+                          {currentProfile === profile && (
+                            <div
+                              className="w-1.5 h-1.5 rounded-full"
+                              style={{ backgroundColor: palette.primary }}
+                            />
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
 
                   {/* Sign Out (only if authenticated) */}
                   {status === 'authenticated' && (

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -5,8 +5,23 @@ function normalizeUrl(value: string): string {
 }
 
 export function getSiteUrl(): string {
-  const url = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXTAUTH_URL ?? LOCALHOST_URL;
-  return normalizeUrl(url);
+  const candidates = [process.env.NEXT_PUBLIC_SITE_URL, process.env.NEXTAUTH_URL, LOCALHOST_URL];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const normalized = normalizeUrl(candidate);
+    if (!normalized) continue;
+
+    try {
+      // Validate URL format and return normalized value when valid.
+      new URL(normalized);
+      return normalized;
+    } catch {
+      // Try next candidate.
+    }
+  }
+
+  return LOCALHOST_URL;
 }
 
 export function absoluteUrl(path: string): string {


### PR DESCRIPTION
https://github.com/Aoi3u/koto-koto/issues/113

## 概要
SEOメタデータとURL解決の堅牢性を改善
aboutページの追加

  ## 変更内容
  - About ページを追加（既存の Terms/Privacy/Licenses と同系統デザイン）
      - /about を新設
      - 英語/日本語の説明セクションを配置
      - canonical 設定を追加
  - ヘッダー設定メニューに About 導線を追加
  - sitemap.xml に /about を追加
  - ルートメタデータを強化
      - OGP/Twitter メタ追加
      - WebSite / Organization の JSON-LD を追加
  - site-url を堅牢化
      - 空文字・不正URL環境変数時に安全にフォールバック
      - 該当ユニットテストを追加